### PR TITLE
Added missing fields from Terrain and Item Editors

### DIFF
--- a/astra/src/editors/item_editor.rs
+++ b/astra/src/editors/item_editor.rs
@@ -194,6 +194,7 @@ impl ItemEditor {
                                 .default_field("Add Target", |item| &mut item.add_target)
                                 .default_field("Add Type", |item| &mut item.add_type)
                                 .default_field("Add Power", |item| &mut item.add_power)
+                                .default_field("Add Range", |item| &mut item.add_range)
                                 .default_field("Add Effect", |item| &mut item.add_effect)
                                 .field("Add Help", |ui, item| {
                                     ui.text_edit_singleline(&mut item.add_help) // TODO: Find the message archive for this key

--- a/astra/src/editors/terrain_editor.rs
+++ b/astra/src/editors/terrain_editor.rs
@@ -64,7 +64,10 @@ impl TerrainDataEditor {
                     .field("Player Defense", |ui, tile| {
                         ui.add(DragValue::new(&mut tile.player_defense))
                     })
-                    .field("Player Avoid", |ui, tile| {
+                    .field("Enemy Defense", |ui, tile| {
+                        ui.add(DragValue::new(&mut tile.enemy_defense))
+                    })
+                   .field("Player Avoid", |ui, tile| {
                         ui.add(DragValue::new(&mut tile.player_avoid))
                     })
                     .field("Enemy Avoid", |ui, tile| {


### PR DESCRIPTION
Item Editor was missing AddRange, used for the range of an item surge enchantment.
Terrain Editor was missing EnemyDefense, such as is seen in miasma tiles; this has been corrected.