### PR TITLE
fix path to work on Mac - does this also work on PC?

### DIFF
--- a/astra-core/src/file_system.rs
+++ b/astra-core/src/file_system.rs
@@ -740,7 +740,7 @@ impl CobaltFileSystemProxy {
         }
 
         // Read a normal bundle.
-        let path_in_rom = Path::new(r"StreamingAssets\aa\Switch\fe_assets_gamedata\")
+        let path_in_rom = Path::new(r"StreamingAssets/aa/Switch/fe_assets_gamedata/")
             .join(&path)
             .with_extension("xml.bundle");
         info!("Loading bundled book from path {}", path_in_rom.display());


### PR DESCRIPTION
When I tried to open my Astra project, I got the error:

```
Failed to load books (fe_assets_gamedata)Caused by:    0: Failed to load achieve    1: file 'StreamingAssets\aa\Switch\fe_assets_gamedata\/achieve.xml.bundle' does not exist in any layer 
```

Changing this path fixed it.

Note: I haven't tested this on PC, so this PR is merely a heads up for the bug, and a reference for what was needed for the path to work on Mac.